### PR TITLE
Fix(storage): Sanitize player data before saving

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -62,7 +62,7 @@ export const storage = {
   addPlayer: async (player: Player): Promise<void> => {
     try {
       const playerDocRef = doc(db, PLAYERS_COLLECTION, player.id);
-      await setDoc(playerDocRef, player);
+      await setDoc(playerDocRef, sanitizeObject(player));
     } catch (error) {
       console.error("Error adding player: ", error);
     }
@@ -73,7 +73,7 @@ export const storage = {
     try {
       const playerDocRef = doc(db, PLAYERS_COLLECTION, updatedPlayer.id);
       // 'merge: true' prevents overwriting fields that are not in the updatedPlayer object
-      await setDoc(playerDocRef, updatedPlayer, { merge: true });
+      await setDoc(playerDocRef, sanitizeObject(updatedPlayer), { merge: true });
     } catch (error) {
       console.error("Error updating player: ", error);
     }
@@ -108,7 +108,7 @@ export const storage = {
     const batch = writeBatch(db);
     newPlayers.forEach(player => {
       const playerDocRef = doc(db, PLAYERS_COLLECTION, player.id);
-      batch.set(playerDocRef, player);
+      batch.set(playerDocRef, sanitizeObject(player));
     });
     try {
       await batch.commit();


### PR DESCRIPTION
The player creation and update forms were failing silently because player objects with `undefined` fields were being sent to Firestore. Firestore does not support `undefined` values, and this caused the `setDoc` operation to fail, preventing new players from being saved.

This commit fixes the issue by wrapping the player object with the `sanitizeObject` helper function in `addPlayer`, `updatePlayer`, and `addMultiplePlayers` in `src/utils/storage.ts`. This ensures that any `undefined` fields are removed from the player object before it is persisted to Firestore, thus preventing the write operation from failing.